### PR TITLE
Modify README.md of chap03

### DIFF
--- a/chap03/README.md
+++ b/chap03/README.md
@@ -161,7 +161,7 @@ For those that are not legal, explain why they are illegal.
 (c) vector<string> svec(10, "null");
 ```
 
-(a) legal: define and value initialize a _vector_ whose elements are _vector_ of _int_.
+(a) uncertain: In the modern C++ standard(like C++ 11),it define and default initialize a _vector_ whose elements are _vector_ of _int_. However, In the past C++ standard(like C++ 98), it will raise compiling error for lacking a _space_ between the two closing angle bracket of the outer _vector_.
 
 (b) illegal: types of _svec_ and _ivec_ are different, we can't initialize a _vector_ with another of 
 different types.


### PR DESCRIPTION
I think it may be inexact in the modified line of this statement: vector<vector<int>> ivec;
1: In the chapter 3.3(page 97), it says in the book that the definition of a vector to a vector will vary on different C++ version. I had tried it on my machine and verified it is right.
2: This statement is a default initialization (page 43), not a value initialization (page 132). 
In C++, value-initializing a std::vector means creating a vector where its elements are explicitly initialized to their default values. For example: 
`std::vector<int> vec(5);  // Initializes 5 elements, all set to 0 (value-initialized for int)`
